### PR TITLE
 [OPTIMIZATION] Split vehicle hud into multiple loops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -248,8 +248,8 @@ end
 
 local function updateDashboard(vehicle)
     local vdata = getVehicleData(vehicle)
-    local engineHealth = 0-- GetVehicleEngineHealth(vehicle)
-    local _, lightsOn, highBeamsOn = 0-- GetVehicleLightsState(vehicle)
+    local engineHealth = GetVehicleEngineHealth(vehicle)
+    local _, lightsOn, highBeamsOn = GetVehicleLightsState(vehicle)
     local indicatorLights = GetVehicleIndicatorLights(vehicle)
     SendNUIMessage({
         type = 'updateVehicle',


### PR DESCRIPTION


Splits vehicle hud into multiple loops so speed can be updated more often without fetching vehicle data everytime
updateVehicleHUD is split to:
updateSpeedometer
updateSpeed
updateDashboard
updateGPS

Also constants for the update period of each of the loops has been added on top of the client.lua, recommended settings and functions are explained there